### PR TITLE
Allow for pulling poorly formatted rotriever.toml files

### DIFF
--- a/lib/commands/packages/_pull/pullSetup.js
+++ b/lib/commands/packages/_pull/pullSetup.js
@@ -63,6 +63,13 @@ module.exports = (d, dependency, dependencyRoot, index) => {
 	 */
 	const rotriever = toml.parse(fs.readFileSync(rotrieverPath))
 
+	if (!rotriever.package) { // Dodgy method, but it works as a hotfix to allow use. Until we find a proper fix, I guess?
+		rotriever = {
+			"package": rotriever,
+			"dependencies": rotriever.dependencies
+		}
+	}
+	
 	const packageName = clean(rotriever.package.name, cleanOptions).toLowerCase()
 	const specifiedName = clean(d, cleanOptions)
 


### PR DESCRIPTION
If kayak runs on a rotriever.toml without a [package] header, then it'll fail.

So instead, we just detect if there isn't one, and then pretend there is. Hacky, since it doesn't actually format it correctly, but this horrid patch does work.